### PR TITLE
windows: use "where" instead of "which" to find c compiler

### DIFF
--- a/pkg/tasks.go
+++ b/pkg/tasks.go
@@ -32,13 +32,22 @@ var tasks = []*task{
 		return "go" + ver, nil
 	}},
 	{"C compiler", "Checking a C compiler is installed", func() (string, error) {
-		cmd := tools.CommandInShell("which", "gcc")
+		var cmd *exec.Cmd
+		if runtime.GOOS == "windows" {
+			cmd = tools.CommandInShell("where", "gcc")
+		} else {
+			cmd = tools.CommandInShell("which", "gcc")
+		}
 		_, err := cmd.Output()
 		if err == nil {
 			return "gcc found", nil
 		}
 
-		cmd = tools.CommandInShell("which", "clang")
+		if runtime.GOOS == "windows" {
+			cmd = tools.CommandInShell("where", "clang")
+		} else {
+			cmd = tools.CommandInShell("which", "clang")
+		}
 		_, err = cmd.Output()
 		if err == nil {
 			return "clang found", nil


### PR DESCRIPTION
fixes #3 

added a check of GOOS and if it's windows pull up `where` instead of `which`. Tested on cmd, powershell and mingw shell and in all of them it works with `where`